### PR TITLE
Don’t use traversal path to include template

### DIFF
--- a/hogan-form.php
+++ b/hogan-form.php
@@ -24,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+define( 'HOGAN_FORM_PATH', plugin_dir_path( __FILE__ ) );
+
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_textdomain' );
 add_action( 'hogan/include_modules', __NAMESPACE__ . '\\register_module' );
 add_action( 'hogan/module/form/register_providers', __NAMESPACE__ . '\\register_default_form_providers' );

--- a/includes/class-form.php
+++ b/includes/class-form.php
@@ -48,7 +48,7 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Form' ) && class_exists( '\\Dekode\\Hogan
 		public function __construct() {
 
 			$this->label    = __( 'Form', 'hogan-form' );
-			$this->template = __DIR__ . '/../assets/template.php';
+			$this->template = HOGAN_FORM_PATH . 'assets/template.php';
 
 			parent::__construct();
 		}


### PR DESCRIPTION
After DekodeInteraktiv/hogan-core#44 was merged using travesel path to include template isn't allowed and the template will not be included. This PR fixes that.