### PR TITLE
Don’t show form title and description as default

### DIFF
--- a/includes/form-providers/class-gravityforms-provider.php
+++ b/includes/form-providers/class-gravityforms-provider.php
@@ -71,8 +71,8 @@ class GravityForms_Provider implements Form_Provider {
 
 		$args = apply_filters( 'hogan/module/form/gravityforms/options', [], $id );
 		$args = wp_parse_args( $args, [
-			'display_title'       => true,
-			'display_description' => true,
+			'display_title'       => false,
+			'display_description' => false,
 			'display_inactive'    => false,
 			'field_values'        => null,
 			'ajax'                => false,


### PR DESCRIPTION
In most cases we want to use the title and lead field in the module for title and description, not the ones from the form. Changed the default value from true to false. 